### PR TITLE
Adding address field to customer 

### DIFF
--- a/lib/kg/accounts/user.ex
+++ b/lib/kg/accounts/user.ex
@@ -7,6 +7,7 @@ defmodule Kg.Accounts.User do
   @derive {Inspect, except: [:password]}
   schema "users" do
     field :email, :string
+    field :address, :string
     field :password, :string, virtual: true
     field :hashed_password, :string
     field :confirmed_at, :naive_datetime
@@ -25,7 +26,7 @@ defmodule Kg.Accounts.User do
   """
   def registration_changeset(user, attrs) do
     user
-    |> cast(attrs, [:email, :password])
+    |> cast(attrs, [:email, :password, :address])
     |> validate_email()
     |> validate_password()
   end

--- a/lib/kg_web/templates/user_registration/new.html.eex
+++ b/lib/kg_web/templates/user_registration/new.html.eex
@@ -15,6 +15,10 @@
   <%= password_input f, :password, required: true %>
   <%= error_tag f, :password %>
 
+  <%= label f, :address %>
+  <%= text_input f, :address, required: false %>
+  <%= error_tag f, :address %>
+
   <div>
     <%= submit "Register" %>
   </div>

--- a/priv/repo/migrations/20210406011539_add_address_to_users.exs
+++ b/priv/repo/migrations/20210406011539_add_address_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Kg.Repo.Migrations.AddAddressToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :address, :string
+    end
+  end
+end

--- a/test/kg/accounts_test.exs
+++ b/test/kg/accounts_test.exs
@@ -91,6 +91,17 @@ defmodule Kg.AccountsTest do
       assert is_nil(user.confirmed_at)
       assert is_nil(user.password)
     end
+
+    test "registers users with an address" do
+      email = unique_user_email()
+      address = "38 Falconers Way"
+      {:ok, user} = Accounts.register_user(%{email: email, password: valid_user_password(), address: address})
+      assert user.email == email
+      assert user.address == address
+      assert is_binary(user.hashed_password)
+      assert is_nil(user.confirmed_at)
+      assert is_nil(user.password)
+    end
   end
 
   describe "make_admin_user/1" do


### PR DESCRIPTION
@jcobert Here we are creating a "migration" that will modify our database to have a new column to store the database. To run this new migration, run `mix ecto.migrate` from the project root. If you want to generate a new migration, run `mix ecto.gen.migration my_example_migration` where `my_example_migration` is something like `add_address_to_users`. You can then run your own migration and modify the corresponding schema, along with the changesets that actually are used in the SQL and modify the database.

Lemme know if anything doesn't make sense and make sure to do things in a separate branch so we can talk about them in Pull Requests.