### PR TITLE
Jc/fix carousel animatin

### DIFF
--- a/assets/js/animations.js
+++ b/assets/js/animations.js
@@ -1,27 +1,30 @@
-alert("test");
+var $ = require('jquery')
+
 function carouselNormalization() {
     var items = $('#testimonial-carousel .carousel-item'), //grab all slides
         heights = [], //create empty array to store height values
         tallest; //create variable to make note of the tallest slide
-    
+        
     if (items.length) {
         function normalizeHeights() {
-            items.each(function() { //add heights to array
-                heights.push($(this).height()); 
+            items.each(function () { //add heights to array
+                heights.push($(this).height());
             });
             tallest = Math.max.apply(null, heights); //cache largest value
-            items.each(function() {
-                $(this).css('min-height',tallest + 'px');
+            items.each(function () {
+                $(this).css('min-height', tallest + 'px');
             });
         };
         normalizeHeights();
-    
+
         $(window).on('resize orientationchange', function () {
             tallest = 0, heights.length = 0; //reset vars
-            items.each(function() {
-                $(this).css('min-height','0'); //reset min-height
-            }); 
+            items.each(function () {
+                $(this).css('min-height', '0'); //reset min-height
+            });
             normalizeHeights(); //run it again 
         });
     }
-    }
+}
+
+carouselNormalization();

--- a/lib/kg_web/templates/layout/app.html.eex
+++ b/lib/kg_web/templates/layout/app.html.eex
@@ -24,6 +24,5 @@
       <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
       <%= @inner_content %>
     </main>
-    <script src="<%= Routes.static_path(@conn, "/js/animations.js") %>"></script>
   </body>
 </html>

--- a/lib/kg_web/templates/page/index.html.eex
+++ b/lib/kg_web/templates/page/index.html.eex
@@ -140,3 +140,5 @@
   </section>
 
 </div>
+
+<script src="<%= Routes.static_path(@conn, "/js/animations.js") %>"></script>


### PR DESCRIPTION
Fixed animations.js by declaring that $ represents jQuery. For some reason with phoenix due to the way the js files are linked and things are routed and rendered and whatnot, that inherent part of jQuery didn't make its way over. 

Regardless, the testimonial carousel now remains at a fixed height. And I moved the script tag to index.html from app.html because I only want it run on the home page, not all pages.