### PR TITLE
Style registration page

### DIFF
--- a/assets/css/_user_registration.scss
+++ b/assets/css/_user_registration.scss
@@ -1,0 +1,95 @@
+:root {
+    --input-padding-x: .75rem;
+    --input-padding-y: .75rem;
+  }
+  
+  .already_logged_in {
+    display: -ms-flexbox;
+    display: -webkit-box;
+    display: flex;
+    -ms-flex-align: center;
+    -ms-flex-pack: center;
+    -webkit-box-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    justify-content: center;
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+  
+  .auth-form-wrapper {
+    display: -ms-flexbox;
+    display: -webkit-box;
+    display: flex;
+    -ms-flex-align: center;
+    -ms-flex-pack: center;
+    -webkit-box-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    justify-content: center;
+    padding-top: 40px;
+    padding-bottom: 40px;
+  
+    .form-signin {
+      width: 100%;
+      max-width: 420px;
+      padding: 15px;
+      margin: 0 auto;
+    }
+  
+    .form-label-group {
+      position: relative;
+      margin-bottom: 1rem;
+    }
+  
+    .form-label-group > input,
+    .form-label-group > label {
+      padding: var(--input-padding-y) var(--input-padding-x);
+    }
+  
+    .form-label-group > label {
+      position: absolute;
+      top: 0;
+      left: 0;
+      display: block;
+      width: 100%;
+      margin-bottom: 0; /* Override default `<label>` margin */
+      line-height: 1.5;
+      color: #495057;
+      border: 1px solid transparent;
+      border-radius: .25rem;
+      transition: all .1s ease-in-out;
+    }
+  
+    .form-label-group input::-webkit-input-placeholder {
+      color: transparent;
+    }
+  
+    .form-label-group input:-ms-input-placeholder {
+      color: transparent;
+    }
+  
+    .form-label-group input::-ms-input-placeholder {
+      color: transparent;
+    }
+  
+    .form-label-group input::-moz-placeholder {
+      color: transparent;
+    }
+  
+    .form-label-group input::placeholder {
+      color: transparent;
+    }
+  
+    .form-label-group input:not(:placeholder-shown) {
+      padding-top: calc(var(--input-padding-y) + var(--input-padding-y) * (2 / 3));
+      padding-bottom: calc(var(--input-padding-y) / 3);
+    }
+  
+    .form-label-group input:not(:placeholder-shown) ~ label {
+      padding-top: calc(var(--input-padding-y) / 3);
+      padding-bottom: calc(var(--input-padding-y) / 3);
+      font-size: 12px;
+      color: #777;
+    }
+  }

--- a/assets/css/_user_registration.scss
+++ b/assets/css/_user_registration.scss
@@ -1,8 +1,3 @@
-// :root {
-//     --input-padding-x: .75rem;
-//     --input-padding-y: .75rem;
-//   }
-  
   .already_logged_in {
     display: -ms-flexbox;
     display: -webkit-box;
@@ -51,11 +46,6 @@
       margin-bottom: 1rem;
     }
   
-    // .form-label-group > input,
-    // .form-label-group > label {
-    //   padding: var(--input-padding-y) var(--input-padding-x);
-    // }
-  
     .form-label-group > label {
       position: absolute;
       top: 0;
@@ -70,36 +60,4 @@
       transition: all .1s ease-in-out;
       display: none;
     }
-  
-    // .form-label-group input::-webkit-input-placeholder {
-    //   color: transparent;
-    // }
-  
-    // .form-label-group input:-ms-input-placeholder {
-    //   color: transparent;
-    // }
-  
-    // .form-label-group input::-ms-input-placeholder {
-    //   color: transparent;
-    // }
-  
-    // .form-label-group input::-moz-placeholder {
-    //   color: transparent;
-    // }
-  
-    // .form-label-group input::placeholder {
-    //   color: transparent;
-    // }
-  
-    // .form-label-group input:not(:placeholder-shown) {
-    //   padding-top: calc(var(--input-padding-y) + var(--input-padding-y) * (2 / 3));
-    //   padding-bottom: calc(var(--input-padding-y) / 3);
-    // }
-  
-    // .form-label-group input:not(:placeholder-shown) ~ label {
-    //   padding-top: calc(var(--input-padding-y) / 3);
-    //   padding-bottom: calc(var(--input-padding-y) / 3);
-    //   font-size: 12px;
-    //   color: #777;
-    // }
   }

--- a/assets/css/_user_registration.scss
+++ b/assets/css/_user_registration.scss
@@ -15,6 +15,15 @@
     justify-content: center;
     padding-top: 5px;
     padding-bottom: 5px;
+
+    p {
+      margin: 0;
+      padding-right: 0.4rem;
+    }
+
+    a {
+      color: $theme-a;
+    }
 }
   
   .auth-form-wrapper {

--- a/assets/css/_user_registration.scss
+++ b/assets/css/_user_registration.scss
@@ -1,7 +1,7 @@
-:root {
-    --input-padding-x: .75rem;
-    --input-padding-y: .75rem;
-  }
+// :root {
+//     --input-padding-x: .75rem;
+//     --input-padding-y: .75rem;
+//   }
   
   .already_logged_in {
     display: -ms-flexbox;
@@ -51,10 +51,10 @@
       margin-bottom: 1rem;
     }
   
-    .form-label-group > input,
-    .form-label-group > label {
-      padding: var(--input-padding-y) var(--input-padding-x);
-    }
+    // .form-label-group > input,
+    // .form-label-group > label {
+    //   padding: var(--input-padding-y) var(--input-padding-x);
+    // }
   
     .form-label-group > label {
       position: absolute;
@@ -68,37 +68,38 @@
       border: 1px solid transparent;
       border-radius: .25rem;
       transition: all .1s ease-in-out;
+      display: none;
     }
   
-    .form-label-group input::-webkit-input-placeholder {
-      color: transparent;
-    }
+    // .form-label-group input::-webkit-input-placeholder {
+    //   color: transparent;
+    // }
   
-    .form-label-group input:-ms-input-placeholder {
-      color: transparent;
-    }
+    // .form-label-group input:-ms-input-placeholder {
+    //   color: transparent;
+    // }
   
-    .form-label-group input::-ms-input-placeholder {
-      color: transparent;
-    }
+    // .form-label-group input::-ms-input-placeholder {
+    //   color: transparent;
+    // }
   
-    .form-label-group input::-moz-placeholder {
-      color: transparent;
-    }
+    // .form-label-group input::-moz-placeholder {
+    //   color: transparent;
+    // }
   
-    .form-label-group input::placeholder {
-      color: transparent;
-    }
+    // .form-label-group input::placeholder {
+    //   color: transparent;
+    // }
   
-    .form-label-group input:not(:placeholder-shown) {
-      padding-top: calc(var(--input-padding-y) + var(--input-padding-y) * (2 / 3));
-      padding-bottom: calc(var(--input-padding-y) / 3);
-    }
+    // .form-label-group input:not(:placeholder-shown) {
+    //   padding-top: calc(var(--input-padding-y) + var(--input-padding-y) * (2 / 3));
+    //   padding-bottom: calc(var(--input-padding-y) / 3);
+    // }
   
-    .form-label-group input:not(:placeholder-shown) ~ label {
-      padding-top: calc(var(--input-padding-y) / 3);
-      padding-bottom: calc(var(--input-padding-y) / 3);
-      font-size: 12px;
-      color: #777;
-    }
+    // .form-label-group input:not(:placeholder-shown) ~ label {
+    //   padding-top: calc(var(--input-padding-y) / 3);
+    //   padding-bottom: calc(var(--input-padding-y) / 3);
+    //   font-size: 12px;
+    //   color: #777;
+    // }
   }

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -6,6 +6,7 @@
 @import "feature";
 @import "footer";
 @import "orders";
+@import "user_registration";
 
 /* Alerts and form errors */
 .alert {

--- a/lib/kg_web/templates/user_registration/new.html.eex
+++ b/lib/kg_web/templates/user_registration/new.html.eex
@@ -1,5 +1,11 @@
 <div class="auth-form-wrapper">
-  <%= form_for @changeset, Routes.user_registration_path(@conn, :create), [as: :session, class: "form-signin"], fn f -> %>
+  <%= form_for @changeset, Routes.user_registration_path(@conn, :create), [class: "form-signin"], fn f -> %>
+    <%= if @changeset.action do %>
+      <div class="alert alert-danger">
+        <p>Oops, something went wrong! Please check the errors below.</p>
+      </div>
+    <% end %>
+
     <div class="text-center mb-4">
       <h1 class="h3 mb-3 font-weight-normal">Create Account</h1>
     </div>
@@ -7,40 +13,35 @@
     <div class="form-label-group">
       <%= text_input f, :first_name, class: "form-control", placeholder: "First name", required: true, autofocus: true %>
       <%= label f, :first_name, "First name", class: "control-label" %>
-      <%= error_tag f, :first_name %>
     </div>
 
     <div class="form-label-group">
       <%= text_input f, :last_name, class: "form-control", placeholder: "Last name", required: true%>
       <%= label f, :last_name, "Last name", class: "control-label" %>
-      <%= error_tag f, :last_name %>
     </div>
 
     <div class="form-label-group">
-      <%= text_input f, :email_address, class: "form-control", placeholder: "Email address", required: true%>
-      <%= label f, :email_address, "Email address", class: "control-label" %>
-      <%= error_tag f, :email_address %>
-    </div>
-
-     <div class="form-label-group">
-      <%= text_input f, :address, class: "form-control", placeholder: "Address", required: false%>
-      <%= label f, :address, "Address", class: "control-label" %>
-      <%= error_tag f, :address %>
+      <%= text_input f, :email, class: "form-control", placeholder: "Email address", required: true%>
+      <%= label f, :email, "Email address", class: "control-label" %>
     </div>
 
     <div class="form-label-group">
       <%= password_input f, :password, class: "form-control", placeholder: "Password", required: true %>
       <%= label f, :password, class: "control-label" %>
-      <%= error_tag f, :address %>
     </div>
 
-    <%= submit "Register", class: "btn btn-lg btn-primary btn-block" %>
+     <div class="form-label-group">
+      <%= text_input f, :address, class: "form-control", placeholder: "Address", required: false%>
+      <%= label f, :address, "Address", class: "control-label" %>
+    </div>
 
-    <%= if @changeset.action do %>
-      <div class="alert alert-danger">
-        <p>Oops, something went wrong! Please check the errors below.</p>
-      </div>
-    <% end %>
+    <%= error_tag f, :last_name %>
+    <%= error_tag f, :email %>
+    <%= error_tag f, :address %>
+    <%= error_tag f, :first_name %>
+    <%= error_tag f, :password %>
+
+    <%= submit "Register", class: "btn btn-lg btn-primary btn-block" %>
   <% end %>
 </div>
 <div class="already_logged_in">

--- a/lib/kg_web/templates/user_registration/new.html.eex
+++ b/lib/kg_web/templates/user_registration/new.html.eex
@@ -45,5 +45,6 @@
   <% end %>
 </div>
 <div class="already_logged_in">
-  Already have an account?<%= link "Log in", to: Routes.user_session_path(@conn, :new) %>
+  <p>Already have an account?</p>
+  <%= link "Log in", to: Routes.user_session_path(@conn, :new) %>
 </div>

--- a/lib/kg_web/templates/user_registration/new.html.eex
+++ b/lib/kg_web/templates/user_registration/new.html.eex
@@ -1,38 +1,48 @@
-<h1>Register</h1>
-
-<%= form_for @changeset, Routes.user_registration_path(@conn, :create), fn f -> %>
-  <%= if @changeset.action do %>
-    <div class="alert alert-danger">
-      <p>Oops, something went wrong! Please check the errors below.</p>
+<div class="auth-form-wrapper">
+  <%= form_for @changeset, Routes.user_registration_path(@conn, :create), [as: :session, class: "form-signin"], fn f -> %>
+    <div class="text-center mb-4">
+      <h1 class="h3 mb-3 font-weight-normal">Create Account</h1>
     </div>
+
+    <div class="form-label-group">
+      <%= text_input f, :first_name, class: "form-control", placeholder: "First name", required: true, autofocus: true %>
+      <%= label f, :first_name, "First name", class: "control-label" %>
+      <%= error_tag f, :first_name %>
+    </div>
+
+    <div class="form-label-group">
+      <%= text_input f, :last_name, class: "form-control", placeholder: "Last name", required: true%>
+      <%= label f, :last_name, "Last name", class: "control-label" %>
+      <%= error_tag f, :last_name %>
+    </div>
+
+    <div class="form-label-group">
+      <%= text_input f, :email_address, class: "form-control", placeholder: "Email address", required: true%>
+      <%= label f, :email_address, "Email address", class: "control-label" %>
+      <%= error_tag f, :email_address %>
+    </div>
+
+     <div class="form-label-group">
+      <%= text_input f, :address, class: "form-control", placeholder: "Address", required: false%>
+      <%= label f, :address, "Address", class: "control-label" %>
+      <%= error_tag f, :address %>
+    </div>
+
+    <div class="form-label-group">
+      <%= password_input f, :password, class: "form-control", placeholder: "Password", required: true %>
+      <%= label f, :password, class: "control-label" %>
+      <%= error_tag f, :address %>
+    </div>
+
+    <%= submit "Register", class: "btn btn-lg btn-primary btn-block" %>
+
+    <%= if @changeset.action do %>
+      <div class="alert alert-danger">
+        <p>Oops, something went wrong! Please check the errors below.</p>
+      </div>
+    <% end %>
   <% end %>
-
-  <%= label f, :first_name %>
-  <%= text_input f, :first_name, required: true %>
-  <%= error_tag f, :first_name %>
-
-  <%= label f, :last_name %>
-  <%= text_input f, :last_name, required: true %>
-  <%= error_tag f, :last_name %>
-
-  <%= label f, :email %>
-  <%= email_input f, :email, required: true %>
-  <%= error_tag f, :email %>
-
-  <%= label f, :password %>
-  <%= password_input f, :password, required: true %>
-  <%= error_tag f, :password %>
-
-  <%= label f, :address %>
-  <%= text_input f, :address, required: false %>
-  <%= error_tag f, :address %>
-
-  <div>
-    <%= submit "Register" %>
-  </div>
-<% end %>
-
-<p>
-  <%= link "Log in", to: Routes.user_session_path(@conn, :new) %> |
-  <%= link "Forgot your password?", to: Routes.user_reset_password_path(@conn, :new) %>
-</p>
+</div>
+<div class="already_logged_in">
+  Already have an account?<%= link "Log in", to: Routes.user_session_path(@conn, :new) %>
+</div>

--- a/lib/kg_web/templates/user_registration/new.html.eex
+++ b/lib/kg_web/templates/user_registration/new.html.eex
@@ -11,28 +11,28 @@
     </div>
 
     <div class="form-label-group">
-      <%= text_input f, :first_name, class: "form-control", placeholder: "First name", required: true, autofocus: true %>
-      <%= label f, :first_name, "First name", class: "control-label" %>
+      <%= text_input f, :first_name, id: "firstName", class: "form-control", placeholder: "First name", required: true, autofocus: true %>
+      <%= label f, :first_name, "First name", for: "firstName", class: "control-label" %>
     </div>
 
     <div class="form-label-group">
-      <%= text_input f, :last_name, class: "form-control", placeholder: "Last name", required: true%>
-      <%= label f, :last_name, "Last name", class: "control-label" %>
+      <%= text_input f, :last_name, id: "lastName", class: "form-control", placeholder: "Last name", required: true%>
+      <%= label f, :last_name, "Last name", for: "lastName", class: "control-label" %>
     </div>
 
     <div class="form-label-group">
-      <%= text_input f, :email, class: "form-control", placeholder: "Email address", required: true%>
-      <%= label f, :email, "Email address", class: "control-label" %>
+      <%= text_input f, :email, id: "email", class: "form-control", placeholder: "Email", required: true%>
+      <%= label f, :email, "Email", for: "email", class: "control-label" %>
     </div>
 
     <div class="form-label-group">
-      <%= password_input f, :password, class: "form-control", placeholder: "Password", required: true %>
-      <%= label f, :password, class: "control-label" %>
+      <%= password_input f, :password, id: "password", class: "form-control", placeholder: "Password", required: true %>
+      <%= label f, :password, for: "password", class: "control-label" %>
     </div>
 
      <div class="form-label-group">
-      <%= text_input f, :address, class: "form-control", placeholder: "Address", required: false%>
-      <%= label f, :address, "Address", class: "control-label" %>
+      <%= text_input f, :address, id: "address", class: "form-control", placeholder: "Address", required: false%>
+      <%= label f, :address, "Address", for: "address", class: "control-label" %>
     </div>
 
     <%= error_tag f, :last_name %>

--- a/test/kg_web/controllers/egg_order_controller_test.exs
+++ b/test/kg_web/controllers/egg_order_controller_test.exs
@@ -31,7 +31,7 @@ defmodule KgWeb.EggOrderControllerTest do
   describe "index" do
     test "lists all egg_orders", %{conn: conn} do
       conn = get(conn, Routes.egg_order_path(conn, :index))
-      assert html_response(conn, 200) =~ "Egg orders"
+      assert html_response(conn, 200) =~ "Your Orders"
     end
   end
 

--- a/test/kg_web/controllers/user_registration_controller_test.exs
+++ b/test/kg_web/controllers/user_registration_controller_test.exs
@@ -7,9 +7,8 @@ defmodule KgWeb.UserRegistrationControllerTest do
     test "renders registration page", %{conn: conn} do
       conn = get(conn, Routes.user_registration_path(conn, :new))
       response = html_response(conn, 200)
-      assert response =~ "<h1>Register</h1>"
+      assert response =~ "Create Account"
       assert response =~ "Log in</a>"
-      assert response =~ "Register</a>"
     end
 
     test "redirects if already logged in", %{conn: conn} do
@@ -46,7 +45,7 @@ defmodule KgWeb.UserRegistrationControllerTest do
         })
 
       response = html_response(conn, 200)
-      assert response =~ "<h1>Register</h1>"
+      assert response =~ "Create Account"
       assert response =~ "must have the @ sign and no spaces"
       assert response =~ "should be at least 12 character"
     end


### PR DESCRIPTION
Add some css for the registration page

@jcobert I am having trouble with something that I feel like should be simple. Hopefully you can help out... I am trying to put a space after `Already have an account` so it is split from the `Log in` link. I added a `whitespace` tag in the `alread-logged-in` css but every time I add that tag, it shifts the link higher than the text so the text isn't aligned. Any ideas?